### PR TITLE
Fix: validação quando a imagem ainda não foi salva

### DIFF
--- a/src/screens/CadastroFornecedor/components/Cadastro/components/DadosLoja/index.jsx
+++ b/src/screens/CadastroFornecedor/components/Cadastro/components/DadosLoja/index.jsx
@@ -175,18 +175,20 @@ export const Loja = ({ loja, fields, index, empresa, logado }) => {
           />
         </div>
         <div className="col-12">
-          <div class="link-comprovante">
-            <label class="form-label">Comprovante de endereço do ponto de venda</label>
-            <div>
-              <a 
-                class="btn btn-comprovante btn-primary" 
-                target="blank" 
-                href={`${empresa.lojas[index].comprovante_end}`}
-              >
-                Visualizar comprovante
-              </a>
+          {logado && empresa && (
+            <div class="link-comprovante">
+              <label class="form-label">Comprovante de endereço do ponto de venda</label>
+              <div>
+                <a 
+                  class="btn btn-comprovante btn-primary" 
+                  target="blank" 
+                  href={`${empresa.lojas[index].comprovante_end}`}
+                >
+                  Visualizar comprovante
+                </a>
+              </div>
             </div>
-          </div>
+          )}
           <Field
             component={FileUpload}
             name={`${loja}.comprovante_end`}


### PR DESCRIPTION
# Proposta

Este PR visa corrigir a validação de quando a loja ainda não tem uma imagem salva.

# Referência do Azure

- 58427

# Tarefas para concluir

- [x] corrigir validação de imagem