### PR TITLE
Bugfix/61329-área-lojistas-remover-validação-no-campo-nome-completo

### DIFF
--- a/src/screens/CadastroFornecedor/components/Cadastro/components/DadosEmpresa/index.jsx
+++ b/src/screens/CadastroFornecedor/components/Cadastro/components/DadosEmpresa/index.jsx
@@ -11,7 +11,6 @@ import {
   validaTelefoneOuCelular,
   validaEmail,
   somenteAlfanumericos,
-  somenteCaracteresEEspacos,
   validaCNPJ,
 } from "helpers/validators";
 import { toastError } from "components/Toast/dialogs";
@@ -178,7 +177,7 @@ export const DadosEmpresa = ({ empresa, form, values }) => {
             type="text"
             placeholder="Nome completo"
             required
-            validate={composeValidators(required, somenteCaracteresEEspacos)}
+            validate={required}
             disabled={empresa}
           />
         </div>


### PR DESCRIPTION
# Proposta

Este PR visa remover validação de acento, cedilha e espaços no campo Nome completo da área de lojistas

# Referência do Azure

- 61329

# Tarefas para concluir

- [x] remover validação de acento, cedilha e espaços no campo Nome completo