### PR TITLE
bugfix 81506 soma valores fornecedor

### DIFF
--- a/src/screens/CadastroFornecedor/components/TabelaPrecos/helpers.js
+++ b/src/screens/CadastroFornecedor/components/TabelaPrecos/helpers.js
@@ -45,6 +45,7 @@ export const validarFormulario = (values, kits) => {
             )
           ) * materialDoKit.unidades;
 
+        total = Math.round(total * 1e2) / 1e2
 
         if (total > parseFloat(kit.preco_maximo)) {
           erro = `Preço máximo do ${kit.nome}: R$ ${kit.preco_maximo.replace(


### PR DESCRIPTION
Este PR:
- corrige problema na soma dos valores na area do fornecedor que impedia cadastrar valores que somassem igual ao limite